### PR TITLE
SAOD-865: typed sanitised errors + request validation for POST /sign-up

### DIFF
--- a/app/uk/gov/hmrc/senioraccountingofficerregistration/connectors/DpsConnector.scala
+++ b/app/uk/gov/hmrc/senioraccountingofficerregistration/connectors/DpsConnector.scala
@@ -16,12 +16,11 @@
 
 package uk.gov.hmrc.senioraccountingofficerregistration.connectors
 
-import play.api.Logging
 import play.api.http.HeaderNames
-import play.api.http.Status.CREATED
 import play.api.libs.json.Json
 import play.api.libs.ws.JsonBodyWritables.writeableOf_JsValue
 import uk.gov.hmrc.http.*
+import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.senioraccountingofficerregistration.config.AppConfig
 import uk.gov.hmrc.senioraccountingofficerregistration.models.{ReplaceSaoSubscriptionRequest, SignUpRequest}
@@ -31,11 +30,11 @@ import scala.concurrent.{ExecutionContext, Future}
 import javax.inject.{Inject, Singleton}
 
 @Singleton
-class DpsConnector @Inject() (httpClient: HttpClientV2, appConfig: AppConfig)(using ExecutionContext) extends Logging {
+class DpsConnector @Inject() (httpClient: HttpClientV2, appConfig: AppConfig)(using ExecutionContext) {
 
-  def replaceSaoSubscription(saoSubscriptionId: String, signUpRequest: SignUpRequest, correlationId: String)(using
+  def replaceSaoSubscription(saoSubscriptionId: String, signUpRequest: SignUpRequest)(using
       HeaderCarrier
-  ): Future[Unit] = {
+  ): Future[HttpResponse] = {
     val replaceRequest: ReplaceSaoSubscriptionRequest =
       ReplaceSaoSubscriptionRequest(signUpRequest.etmpSafeId, signUpRequest.nominatedCompany, signUpRequest.contacts)
     httpClient
@@ -45,15 +44,5 @@ class DpsConnector @Inject() (httpClient: HttpClientV2, appConfig: AppConfig)(us
       )
       .withBody(Json.toJson(replaceRequest))
       .execute[HttpResponse]
-      .map {
-        case response if response.status == CREATED => ()
-        case response                               => {
-          logger.error(s"DPS API failed with CorrelationId: $correlationId")
-          throw UpstreamErrorResponse(
-            s"DPS api returned ${response.status}",
-            response.status
-          )
-        }
-      }
   }
 }

--- a/app/uk/gov/hmrc/senioraccountingofficerregistration/connectors/EtmpSubscriptionConnector.scala
+++ b/app/uk/gov/hmrc/senioraccountingofficerregistration/connectors/EtmpSubscriptionConnector.scala
@@ -17,18 +17,13 @@
 package uk.gov.hmrc.senioraccountingofficerregistration.connectors
 
 import play.api.http.HeaderNames
-import play.api.http.Status.CREATED
 import play.api.libs.json.Json
 import play.api.libs.ws.writeableOf_JsValue
 import uk.gov.hmrc.http.*
 import uk.gov.hmrc.http.HttpReads.Implicits.*
 import uk.gov.hmrc.http.client.HttpClientV2
 import uk.gov.hmrc.senioraccountingofficerregistration.config.AppConfig
-import uk.gov.hmrc.senioraccountingofficerregistration.models.{
-  EtmpSubscriptionRequest,
-  EtmpSuccessResponse,
-  SignUpRequest
-}
+import uk.gov.hmrc.senioraccountingofficerregistration.models.{EtmpSubscriptionRequest, SignUpRequest}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -42,7 +37,7 @@ class EtmpSubscriptionConnector @Inject() (httpClient: HttpClientV2, appConfig: 
     ExecutionContext
 ) {
 
-  def signUp(signUpRequest: SignUpRequest, correlationId: String)(using HeaderCarrier): Future[EtmpSuccessResponse] =
+  def signUp(signUpRequest: SignUpRequest, correlationId: String)(using HeaderCarrier): Future[HttpResponse] =
     httpClient
       .post(url"${appConfig.etmpSubscriptionUrl}")
       .withBody(Json.toJson(EtmpSubscriptionRequest("UTR", signUpRequest.nominatedCompany.utr)))
@@ -54,12 +49,4 @@ class EtmpSubscriptionConnector @Inject() (httpClient: HttpClientV2, appConfig: 
         "X-Receipt-Date" -> DateTimeFormatter.ISO_INSTANT.format(clock.instant().truncatedTo(ChronoUnit.SECONDS))
       )
       .execute[HttpResponse]
-      .map {
-        case response if response.status == CREATED => response.json.as[EtmpSuccessResponse]
-        case response                               =>
-          throw UpstreamErrorResponse(
-            s"ETMP subscription API returned ${response.status}",
-            response.status
-          )
-      }
 }

--- a/app/uk/gov/hmrc/senioraccountingofficerregistration/connectors/TaxEnrolmentsConnector.scala
+++ b/app/uk/gov/hmrc/senioraccountingofficerregistration/connectors/TaxEnrolmentsConnector.scala
@@ -31,17 +31,9 @@ import javax.inject.{Inject, Singleton}
 @Singleton
 class TaxEnrolmentsConnector @Inject() (httpClient: HttpClientV2, appConfig: AppConfig)(using ExecutionContext) {
 
-  def enrol(request: TaxEnrolmentRequest)(using HeaderCarrier): Future[Unit] =
+  def enrol(request: TaxEnrolmentRequest)(using HeaderCarrier): Future[HttpResponse] =
     httpClient
       .put(url"${appConfig.taxEnrolmentsDsaoEnrolmentUrl}")
       .withBody(Json.toJson(request))
       .execute[HttpResponse]
-      .map {
-        case response if response.status >= 200 && response.status < 300 => ()
-        case response                                                    =>
-          throw UpstreamErrorResponse(
-            s"Tax enrolments API returned ${response.status}",
-            response.status
-          )
-      }
 }

--- a/app/uk/gov/hmrc/senioraccountingofficerregistration/controllers/SignUpController.scala
+++ b/app/uk/gov/hmrc/senioraccountingofficerregistration/controllers/SignUpController.scala
@@ -16,11 +16,13 @@
 
 package uk.gov.hmrc.senioraccountingofficerregistration.controllers
 
+import play.api.Logging
 import play.api.libs.json.Json
 import play.api.mvc.{Action, ControllerComponents}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
-import uk.gov.hmrc.senioraccountingofficerregistration.models.SignUpRequest
+import uk.gov.hmrc.senioraccountingofficerregistration.models.*
 import uk.gov.hmrc.senioraccountingofficerregistration.services.SignUpService
+import uk.gov.hmrc.senioraccountingofficerregistration.services.SignUpService.SignUpResult
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -30,7 +32,8 @@ import javax.inject.{Inject, Singleton}
 
 @Singleton()
 class SignUpController @Inject() (cc: ControllerComponents, signUpService: SignUpService)(using ExecutionContext)
-    extends BackendController(cc) {
+    extends BackendController(cc)
+    with Logging {
 
   def signUp: Action[SignUpRequest] = Action.async(parse.json[SignUpRequest]) { implicit request =>
     request.headers
@@ -41,9 +44,25 @@ class SignUpController @Inject() (cc: ControllerComponents, signUpService: SignU
         Try(UUID.fromString(header)).fold(
           _ => Future.successful(BadRequest("Invalid CorrelationId header")),
           header =>
-            signUpService
-              .signUp(request.body, header.toString)
-              .map(signUpResponse => Ok(Json.toJson(signUpResponse)))
+            signUpService.signUp(request.body, header.toString).map {
+              case SignUpResult.Success(subscriptionId) =>
+                Ok(Json.toJson(SignUpResponse(subscriptionId)))
+              case SignUpResult.MalformedResponse(downstreamService) =>
+                logger.warn(s"[SignUp][$downstreamService][MalformedResponse][CorrelationId=$header]")
+                BadGateway(Json.toJson(ApiError(Reason.DOWNSTREAM_SERVICE_MISALIGNMENT)))
+              case SignUpResult.BadRequestFailure(downstreamService) =>
+                logger.warn(s"[SignUp][$downstreamService][BAD_REQUEST][CorrelationId=$header]")
+                InternalServerError(Json.toJson(ApiError(Reason.DOWNSTREAM_SERVICE_MISALIGNMENT)))
+              case SignUpResult.InternalServerFailure(downstreamService) =>
+                logger.warn(s"[SignUp][$downstreamService][INTERNAL_SERVER_ERROR][CorrelationId=$header]")
+                BadGateway(Json.toJson(ApiError(Reason.DOWNSTREAM_SERVICE_ERROR)))
+              case SignUpResult.ServiceUnavailableFailure(downstreamService) =>
+                logger.warn(s"[SignUp][$downstreamService][SERVICE_UNAVAILABLE][CorrelationId=$header]")
+                BadGateway(Json.toJson(ApiError(Reason.DOWNSTREAM_SERVICE_UNAVAILABLE)))
+              case SignUpResult.UnknownFailure(downstreamService, status) =>
+                logger.warn(s"[SignUp][$downstreamService][Unknown][CorrelationId=$header]status=$status")
+                BadGateway(Json.toJson(ApiError(Reason.DOWNSTREAM_SERVICE_MISALIGNMENT)))
+            }
         )
       }
   }

--- a/app/uk/gov/hmrc/senioraccountingofficerregistration/models/ApiError.scala
+++ b/app/uk/gov/hmrc/senioraccountingofficerregistration/models/ApiError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 HM Revenue & Customs
+ * Copyright 2026 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,23 +16,20 @@
 
 package uk.gov.hmrc.senioraccountingofficerregistration.models
 
-import play.api.libs.functional.syntax.*
 import play.api.libs.json.*
 
-final case class SignUpRequest(
-    etmpSafeId: String,
-    nominatedCompany: NominatedCompany,
-    contacts: List[Contact]
-)
+enum Reason {
+  case DOWNSTREAM_SERVICE_ERROR
+  case DOWNSTREAM_SERVICE_UNAVAILABLE
+  case DOWNSTREAM_SERVICE_MISALIGNMENT
+}
 
-object SignUpRequest {
+object Reason {
+  given Writes[Reason] = Writes(reason => JsString(reason.toString))
+}
 
-  private val reads: Reads[SignUpRequest] =
-    ((JsPath \ "etmpSafeId").read[String] and
-      (JsPath \ "nominatedCompany").read[NominatedCompany] and
-      (JsPath \ "contacts")
-        .read[List[Contact]]
-        .filter(JsonValidationError("error.contacts.empty"))(_.nonEmpty))(SignUpRequest.apply)
+final case class ApiError(reason: Reason)
 
-  given OFormat[SignUpRequest] = OFormat(reads, Json.writes[SignUpRequest])
+object ApiError {
+  given OWrites[ApiError] = Json.writes[ApiError]
 }

--- a/app/uk/gov/hmrc/senioraccountingofficerregistration/models/ReplaceSaoSubscriptionRequest.scala
+++ b/app/uk/gov/hmrc/senioraccountingofficerregistration/models/ReplaceSaoSubscriptionRequest.scala
@@ -16,7 +16,8 @@
 
 package uk.gov.hmrc.senioraccountingofficerregistration.models
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.functional.syntax.*
+import play.api.libs.json.*
 
 final case class ReplaceSaoSubscriptionRequest(
     etmpSafeId: String,
@@ -37,5 +38,14 @@ object NominatedCompany {
 final case class Contact(name: String, email: String, status: String, language: String)
 
 object Contact {
-  given OFormat[Contact] = Json.format[Contact]
+
+  private[models] val emailRegex = """^[^\s@.]+(\.[^\s@.]+)*@[^\s@.]+(\.[^\s@.]+)+$""".r
+
+  private val reads: Reads[Contact] =
+    ((JsPath \ "name").read[String] and
+      (JsPath \ "email").read[String](Reads.pattern(emailRegex, "error.email.invalid")) and
+      (JsPath \ "status").read[String] and
+      (JsPath \ "language").read[String])(Contact.apply)
+
+  given OFormat[Contact] = OFormat(reads, Json.writes[Contact])
 }

--- a/app/uk/gov/hmrc/senioraccountingofficerregistration/services/SignUpService.scala
+++ b/app/uk/gov/hmrc/senioraccountingofficerregistration/services/SignUpService.scala
@@ -16,15 +16,19 @@
 
 package uk.gov.hmrc.senioraccountingofficerregistration.services
 
-import uk.gov.hmrc.http.HeaderCarrier
+import play.api.http.Status.*
+import play.api.libs.json.Json
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.senioraccountingofficerregistration.connectors.{
   DpsConnector,
   EtmpSubscriptionConnector,
   TaxEnrolmentsConnector
 }
-import uk.gov.hmrc.senioraccountingofficerregistration.models.{SignUpRequest, SignUpResponse, TaxEnrolmentRequest}
+import uk.gov.hmrc.senioraccountingofficerregistration.models.{EtmpSuccessResponse, SignUpRequest, TaxEnrolmentRequest}
+import uk.gov.hmrc.senioraccountingofficerregistration.services.SignUpService.*
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 import javax.inject.{Inject, Singleton}
 
@@ -35,12 +39,69 @@ class SignUpService @Inject() (
     dpsConnector: DpsConnector
 )(using ExecutionContext) {
 
-  def signUp(signUpRequest: SignUpRequest, correlationId: String)(using HeaderCarrier): Future[SignUpResponse] = {
-    for {
-      etmpSuccessResponse <- etmpSubscriptionConnector.signUp(signUpRequest, correlationId)
-      subscriptionId = etmpSuccessResponse.success.dsaoIdNumber
-      _ <- dpsConnector.replaceSaoSubscription(subscriptionId, signUpRequest, correlationId)
-      _ <- taxEnrolmentsConnector.enrol(TaxEnrolmentRequest(signUpRequest, etmpSuccessResponse))
-    } yield SignUpResponse(subscriptionId)
+  def signUp(signUpRequest: SignUpRequest, correlationId: String)(using HeaderCarrier): Future[SignUpResult] =
+    etmpSubscriptionConnector.signUp(signUpRequest, correlationId).map(sanitiseEtmp).flatMap {
+      case Left(failure)              => Future.successful(failure)
+      case Right(etmpSuccessResponse) =>
+        val subscriptionId = etmpSuccessResponse.success.dsaoIdNumber
+        dpsConnector.replaceSaoSubscription(subscriptionId, signUpRequest).map(sanitiseDps).flatMap {
+          case Left(failure) => Future.successful(failure)
+          case Right(_)      =>
+            taxEnrolmentsConnector
+              .enrol(TaxEnrolmentRequest(signUpRequest, etmpSuccessResponse))
+              .map(sanitiseTaxEnrolments)
+              .map {
+                case Left(failure) => failure
+                case Right(_)      => SignUpResult.Success(subscriptionId)
+              }
+        }
+    }
+
+  private def sanitiseEtmp(response: HttpResponse): Either[SignUpResult & Failure, EtmpSuccessResponse] =
+    response match {
+      case HttpResponse(CREATED, body, _) =>
+        Try(Json.parse(body).as[EtmpSuccessResponse]).fold(
+          _ => Left(SignUpResult.MalformedResponse(DownstreamService.ETMP)),
+          Right(_)
+        )
+      case HttpResponse(status, _, _) => Left(toFailure(DownstreamService.ETMP, status))
+    }
+
+  private def sanitiseDps(response: HttpResponse): Either[SignUpResult & Failure, Unit] =
+    response match {
+      case HttpResponse(CREATED, _, _) => Right(())
+      case HttpResponse(status, _, _)  => Left(toFailure(DownstreamService.DPS, status))
+    }
+
+  private def sanitiseTaxEnrolments(response: HttpResponse): Either[SignUpResult & Failure, Unit] =
+    response.status match {
+      case status if status >= 200 && status < 300 => Right(())
+      case status                                  => Left(toFailure(DownstreamService.TAX_ENROLMENTS, status))
+    }
+}
+
+object SignUpService {
+
+  enum DownstreamService {
+    case ETMP, DPS, TAX_ENROLMENTS
   }
+
+  sealed trait Failure
+
+  enum SignUpResult {
+    case Success(subscriptionId: String)
+    case MalformedResponse(downstreamService: DownstreamService)           extends SignUpResult, Failure
+    case BadRequestFailure(downstreamService: DownstreamService)           extends SignUpResult, Failure
+    case InternalServerFailure(downstreamService: DownstreamService)       extends SignUpResult, Failure
+    case ServiceUnavailableFailure(downstreamService: DownstreamService)   extends SignUpResult, Failure
+    case UnknownFailure(downstreamService: DownstreamService, status: Int) extends SignUpResult, Failure
+  }
+
+  private def toFailure(downstreamService: DownstreamService, status: Int): SignUpResult & Failure =
+    status match {
+      case BAD_REQUEST           => SignUpResult.BadRequestFailure(downstreamService)
+      case INTERNAL_SERVER_ERROR => SignUpResult.InternalServerFailure(downstreamService)
+      case SERVICE_UNAVAILABLE   => SignUpResult.ServiceUnavailableFailure(downstreamService)
+      case other                 => SignUpResult.UnknownFailure(downstreamService, other)
+    }
 }

--- a/app/uk/gov/hmrc/senioraccountingofficerregistration/services/SignUpService.scala
+++ b/app/uk/gov/hmrc/senioraccountingofficerregistration/services/SignUpService.scala
@@ -52,19 +52,17 @@ class SignUpService @Inject() (
     } yield SignUpResult.Success(subscriptionId)).merge[SignUpResult]
 
   private def sanitiseEtmp(response: HttpResponse): Either[SignUpResult & Failure, EtmpSuccessResponse] =
-    response match {
-      case HttpResponse(CREATED, body, _) =>
-        Try(Json.parse(body).as[EtmpSuccessResponse]).fold(
-          _ => Left(SignUpResult.MalformedResponse(DownstreamService.ETMP)),
-          Right(_)
-        )
-      case HttpResponse(status, _, _) => Left(toFailure(DownstreamService.ETMP, status))
+    response.status match {
+      case CREATED =>
+        Try(Json.parse(response.body).as[EtmpSuccessResponse]).toEither
+          .leftMap(_ => SignUpResult.MalformedResponse(DownstreamService.ETMP))
+      case status => Left(toFailure(DownstreamService.ETMP, status))
     }
 
   private def sanitiseDps(response: HttpResponse): Either[SignUpResult & Failure, Unit] =
-    response match {
-      case HttpResponse(CREATED, _, _) => Right(())
-      case HttpResponse(status, _, _)  => Left(toFailure(DownstreamService.DPS, status))
+    response.status match {
+      case CREATED => Right(())
+      case status  => Left(toFailure(DownstreamService.DPS, status))
     }
 
   private def sanitiseTaxEnrolments(response: HttpResponse): Either[SignUpResult & Failure, Unit] =

--- a/app/uk/gov/hmrc/senioraccountingofficerregistration/services/SignUpService.scala
+++ b/app/uk/gov/hmrc/senioraccountingofficerregistration/services/SignUpService.scala
@@ -16,6 +16,8 @@
 
 package uk.gov.hmrc.senioraccountingofficerregistration.services
 
+import cats.data.EitherT
+import cats.implicits.*
 import play.api.http.Status.*
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
@@ -40,22 +42,14 @@ class SignUpService @Inject() (
 )(using ExecutionContext) {
 
   def signUp(signUpRequest: SignUpRequest, correlationId: String)(using HeaderCarrier): Future[SignUpResult] =
-    etmpSubscriptionConnector.signUp(signUpRequest, correlationId).map(sanitiseEtmp).flatMap {
-      case Left(failure)              => Future.successful(failure)
-      case Right(etmpSuccessResponse) =>
-        val subscriptionId = etmpSuccessResponse.success.dsaoIdNumber
-        dpsConnector.replaceSaoSubscription(subscriptionId, signUpRequest).map(sanitiseDps).flatMap {
-          case Left(failure) => Future.successful(failure)
-          case Right(_)      =>
-            taxEnrolmentsConnector
-              .enrol(TaxEnrolmentRequest(signUpRequest, etmpSuccessResponse))
-              .map(sanitiseTaxEnrolments)
-              .map {
-                case Left(failure) => failure
-                case Right(_)      => SignUpResult.Success(subscriptionId)
-              }
-        }
-    }
+    (for {
+      etmpSuccessResponse <- EitherT(etmpSubscriptionConnector.signUp(signUpRequest, correlationId).map(sanitiseEtmp))
+      subscriptionId = etmpSuccessResponse.success.dsaoIdNumber
+      _ <- EitherT(dpsConnector.replaceSaoSubscription(subscriptionId, signUpRequest).map(sanitiseDps))
+      _ <- EitherT(
+        taxEnrolmentsConnector.enrol(TaxEnrolmentRequest(signUpRequest, etmpSuccessResponse)).map(sanitiseTaxEnrolments)
+      )
+    } yield SignUpResult.Success(subscriptionId)).merge[SignUpResult]
 
   private def sanitiseEtmp(response: HttpResponse): Either[SignUpResult & Failure, EtmpSuccessResponse] =
     response match {

--- a/bruno/post sign up.yml
+++ b/bruno/post sign up.yml
@@ -16,17 +16,19 @@ http:
     data: |-
       {
         "etmpSafeId": "1234567890",
-        "contacts": [{
-          "name": "String",
-          "email": "String", 
-          "status": "String"
-        }],
         "nominatedCompany": {
           "name": "Test Company Ltd PLC",
           "utr": "2233445567",
           "crn": "11223344"
         },
-        "language": "en-GB"
+        "contacts": [
+          {
+            "name": "Jane Doe",
+            "email": "jane.doe@example.com",
+            "status": "Active",
+            "language": "en-GB"
+          }
+        ]
       }
 
 settings:

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,7 +10,8 @@ object AppDependencies {
 
   val compile: Seq[ModuleID] = Seq(
     "uk.gov.hmrc"       %% "bootstrap-backend-play-30" % bootstrapVersion,
-    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"        % hmrcMongoVersion
+    "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-30"        % hmrcMongoVersion,
+    "org.typelevel"     %% "cats-core"                 % "2.13.0"
   )
 
   val test: Seq[ModuleID] = Seq(

--- a/test/uk/gov/hmrc/senioraccountingofficerregistration/TestData.scala
+++ b/test/uk/gov/hmrc/senioraccountingofficerregistration/TestData.scala
@@ -30,8 +30,8 @@ trait TestData {
 
   protected def generateContacts(): List[Contact] =
     List(
-      Contact("contact 1", "contact1@example.com", "en-GB", "status"),
-      Contact("contact 2", "contact2@example.com", "en-GB", "status")
+      Contact("contact 1", "contact1@example.com", "active", "en-GB"),
+      Contact("contact 2", "contact2@example.com", "active", "en-GB")
     )
 
   protected def generateNominatedCompany(seed: Int): NominatedCompany =

--- a/test/uk/gov/hmrc/senioraccountingofficerregistration/TestData.scala
+++ b/test/uk/gov/hmrc/senioraccountingofficerregistration/TestData.scala
@@ -30,12 +30,12 @@ trait TestData {
 
   protected def generateContacts(): List[Contact] =
     List(
-      Contact("contact 1", "contact1@example.com", "active", "en-GB"),
-      Contact("contact 2", "contact2@example.com", "active", "en-GB")
+      Contact(name = "contact 1", email = "contact1@example.com", status = "active", language = "en-GB"),
+      Contact(name = "contact 2", email = "contact2@example.com", status = "active", language = "en-GB")
     )
 
   protected def generateNominatedCompany(seed: Int): NominatedCompany =
-    NominatedCompany("example company", utr(seed + 1), crn(seed + 2))
+    NominatedCompany(name = "example company", utr = utr(seed + 1), crn = crn(seed + 2))
 
   protected def generateSignUpRequest(seed: Int): SignUpRequest = {
     SignUpRequest(

--- a/test/uk/gov/hmrc/senioraccountingofficerregistration/connectors/DpsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/senioraccountingofficerregistration/connectors/DpsConnectorSpec.scala
@@ -28,12 +28,10 @@ import play.api.Application
 import play.api.http.{HeaderNames, MimeTypes, Status}
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.{JsObject, Json}
-import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongo.play.PlayMongoModule
 import uk.gov.hmrc.senioraccountingofficerregistration.TestData
 import uk.gov.hmrc.senioraccountingofficerregistration.models.ReplaceSaoSubscriptionRequest
-
-import java.util.UUID
 
 class DpsConnectorSpec
     extends AnyWordSpec
@@ -69,10 +67,9 @@ class DpsConnectorSpec
   private given HeaderCarrier = HeaderCarrier()
 
   private lazy val connector = app.injector.instanceOf[DpsConnector]
-  private val correlationId  = UUID.randomUUID().toString
 
   "replaceSaoSubscription" should {
-    "return 201 with empty payload" in {
+    "return the raw 201 response with empty payload" in {
       val signUpRequest                 = generateSignUpRequest(2)
       val replaceSaoSubscriptionRequest =
         ReplaceSaoSubscriptionRequest(signUpRequest.etmpSafeId, signUpRequest.nominatedCompany, signUpRequest.contacts)
@@ -85,26 +82,26 @@ class DpsConnectorSpec
           .withRequestBody(equalToJson(Json.stringify(expectedSignUpRequest)))
           .willReturn(aResponse().withStatus(Status.CREATED))
       )
-      connector.replaceSaoSubscription(subscriptionId, signUpRequest, correlationId).futureValue shouldBe ()
+      connector.replaceSaoSubscription(subscriptionId, signUpRequest).futureValue.status shouldBe Status.CREATED
     }
-  }
 
-  "fail when DPS returns a non 201 response" in {
-    val signUpRequest                 = generateSignUpRequest(2)
-    val replaceSaoSubscriptionRequest =
-      ReplaceSaoSubscriptionRequest(signUpRequest.etmpSafeId, signUpRequest.nominatedCompany, signUpRequest.contacts)
-    val expectedSignUpRequest = Json.toJson(replaceSaoSubscriptionRequest).as[JsObject]
-    val subscriptionId        = "456"
+    "return the raw response without throwing when DPS returns a non-201 status" in {
+      val signUpRequest                 = generateSignUpRequest(2)
+      val replaceSaoSubscriptionRequest =
+        ReplaceSaoSubscriptionRequest(signUpRequest.etmpSafeId, signUpRequest.nominatedCompany, signUpRequest.contacts)
+      val expectedSignUpRequest = Json.toJson(replaceSaoSubscriptionRequest).as[JsObject]
+      val subscriptionId        = "456"
 
-    wireMockServer.stubFor(
-      put(s"/subscriptions/${subscriptionId}")
-        .withHeader(HeaderNames.CONTENT_TYPE, containing(MimeTypes.JSON))
-        .withRequestBody(equalToJson(Json.stringify(expectedSignUpRequest)))
-        .willReturn(aResponse().withStatus(Status.INTERNAL_SERVER_ERROR))
-    )
-    connector
-      .replaceSaoSubscription(subscriptionId, signUpRequest, correlationId)
-      .failed
-      .futureValue shouldBe a[UpstreamErrorResponse]
+      wireMockServer.stubFor(
+        put(s"/subscriptions/${subscriptionId}")
+          .withHeader(HeaderNames.CONTENT_TYPE, containing(MimeTypes.JSON))
+          .withRequestBody(equalToJson(Json.stringify(expectedSignUpRequest)))
+          .willReturn(aResponse().withStatus(Status.INTERNAL_SERVER_ERROR))
+      )
+      connector
+        .replaceSaoSubscription(subscriptionId, signUpRequest)
+        .futureValue
+        .status shouldBe Status.INTERNAL_SERVER_ERROR
+    }
   }
 }

--- a/test/uk/gov/hmrc/senioraccountingofficerregistration/connectors/EtmpSubscriptionConnectorSpec.scala
+++ b/test/uk/gov/hmrc/senioraccountingofficerregistration/connectors/EtmpSubscriptionConnectorSpec.scala
@@ -31,6 +31,7 @@ import play.api.libs.json.Json
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongo.play.PlayMongoModule
 import uk.gov.hmrc.senioraccountingofficerregistration.TestData
+import uk.gov.hmrc.senioraccountingofficerregistration.models.EtmpSuccessResponse
 
 import java.util.UUID
 
@@ -71,7 +72,7 @@ class EtmpSubscriptionConnectorSpec
   private val correlationId  = UUID.randomUUID().toString
 
   "signUp" should {
-    "post the sign-up request to ETMP and return the subscription ID" in {
+    "post the sign-up request to ETMP and return the raw 201 response" in {
       val request  = generateSignUpRequest(seed = 1)
       val response = generateEtmpSuccessResponse(seed = 4)
 
@@ -97,7 +98,20 @@ class EtmpSubscriptionConnectorSpec
           )
       )
 
-      connector.signUp(request, correlationId).futureValue shouldBe response
+      val result = connector.signUp(request, correlationId).futureValue
+      result.status shouldBe Status.CREATED
+      result.json.as[EtmpSuccessResponse] shouldBe response
+    }
+
+    "return the raw response without throwing on a non-201 status" in {
+      val request = generateSignUpRequest(seed = 1)
+
+      wireMockServer.stubFor(
+        post(urlEqualTo("/RESTAdapter/dsao/subscription"))
+          .willReturn(aResponse().withStatus(Status.INTERNAL_SERVER_ERROR))
+      )
+
+      connector.signUp(request, correlationId).futureValue.status shouldBe Status.INTERNAL_SERVER_ERROR
     }
   }
 }

--- a/test/uk/gov/hmrc/senioraccountingofficerregistration/connectors/TaxEnrolmentsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/senioraccountingofficerregistration/connectors/TaxEnrolmentsConnectorSpec.scala
@@ -28,7 +28,7 @@ import play.api.Application
 import play.api.http.{HeaderNames, MimeTypes, Status}
 import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json.Json
-import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongo.play.PlayMongoModule
 import uk.gov.hmrc.senioraccountingofficerregistration.models.{TaxEnrolmentKnownFact, TaxEnrolmentRequest}
 
@@ -73,7 +73,7 @@ class TaxEnrolmentsConnectorSpec
   )
 
   "enrol" should {
-    "put the DSAO enrolment request to tax-enrolments" in {
+    "put the DSAO enrolment request to tax-enrolments and return the raw 2xx response" in {
       wireMockServer.stubFor(
         put(urlEqualTo("/tax-enrolments/service/HMRC-DSAO-ORG/enrolment"))
           .withHeader(HeaderNames.CONTENT_TYPE, containing(MimeTypes.JSON))
@@ -81,16 +81,16 @@ class TaxEnrolmentsConnectorSpec
           .willReturn(aResponse().withStatus(Status.NO_CONTENT))
       )
 
-      connector.enrol(request).futureValue shouldBe ()
+      connector.enrol(request).futureValue.status shouldBe Status.NO_CONTENT
     }
 
-    "fail when tax-enrolments returns a non-2xx response" in {
+    "return the raw response without throwing on a non-2xx status" in {
       wireMockServer.stubFor(
         put(urlEqualTo("/tax-enrolments/service/HMRC-DSAO-ORG/enrolment"))
           .willReturn(aResponse().withStatus(Status.INTERNAL_SERVER_ERROR))
       )
 
-      connector.enrol(request).failed.futureValue shouldBe a[UpstreamErrorResponse]
+      connector.enrol(request).futureValue.status shouldBe Status.INTERNAL_SERVER_ERROR
     }
   }
 }

--- a/test/uk/gov/hmrc/senioraccountingofficerregistration/controllers/SignUpControllerSpec.scala
+++ b/test/uk/gov/hmrc/senioraccountingofficerregistration/controllers/SignUpControllerSpec.scala
@@ -22,7 +22,8 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 import play.api.http.{HeaderNames, MimeTypes, Status}
-import play.api.libs.json.Json
+import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.mvc.Result
 import play.api.test.Helpers.*
 import play.api.test.{FakeRequest, Helpers}
 import uk.gov.hmrc.http.HeaderCarrier
@@ -32,8 +33,9 @@ import uk.gov.hmrc.senioraccountingofficerregistration.connectors.{
   EtmpSubscriptionConnector,
   TaxEnrolmentsConnector
 }
-import uk.gov.hmrc.senioraccountingofficerregistration.models.{SignUpRequest, SignUpResponse}
+import uk.gov.hmrc.senioraccountingofficerregistration.models.*
 import uk.gov.hmrc.senioraccountingofficerregistration.services.SignUpService
+import uk.gov.hmrc.senioraccountingofficerregistration.services.SignUpService.{DownstreamService, SignUpResult}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -54,15 +56,26 @@ class SignUpControllerSpec extends AnyWordSpec with Matchers with BeforeAndAfter
   private val taxEnrolmentsConnector    = mock(classOf[TaxEnrolmentsConnector])
   private val dpsConnector              = mock(classOf[DpsConnector])
 
-  private val signUpService = new SignUpService(etmpSubscriptionConnector, taxEnrolmentsConnector, dpsConnector) {
-    override def signUp(request: SignUpRequest, header: String)(using HeaderCarrier): Future[SignUpResponse] = {
-      header shouldBe correlationId
-      request shouldBe signUpRequest
-      Future.successful(signUpResponse)
+  private def stubService(onSignUp: (SignUpRequest, String) => Future[SignUpResult]): SignUpService =
+    new SignUpService(etmpSubscriptionConnector, taxEnrolmentsConnector, dpsConnector) {
+      override def signUp(request: SignUpRequest, header: String)(using HeaderCarrier): Future[SignUpResult] =
+        onSignUp(request, header)
     }
-  }
 
-  private val controller = new SignUpController(Helpers.stubControllerComponents(), signUpService)
+  private def controllerReturning(result: SignUpResult): SignUpController =
+    new SignUpController(Helpers.stubControllerComponents(), stubService((_, _) => Future.successful(result)))
+
+  private def postSignUp(
+      controller: SignUpController,
+      body: JsValue,
+      withCorrelationId: Boolean = true
+  ): Future[Result] = {
+    val base    = FakeRequest("POST", "/sign-up").withHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
+    val request =
+      if withCorrelationId then base.withHeaders("CorrelationId" -> correlationId).withJsonBody(body)
+      else base.withJsonBody(body)
+    call(controller.signUp, request)
+  }
 
   override def afterAll(): Unit = {
     actorSystem.terminate()
@@ -70,33 +83,31 @@ class SignUpControllerSpec extends AnyWordSpec with Matchers with BeforeAndAfter
   }
 
   "POST /sign-up" should {
-    "return 200 with the subscription ID returned by ETMP" in {
-      val result = call(
-        controller.signUp,
-        FakeRequest("POST", "/sign-up")
-          .withHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
-          .withHeaders("CorrelationId" -> correlationId)
-          .withJsonBody(Json.toJson(signUpRequest))
-      )
+    "return 200 with the subscription ID when the sign up succeeds" in {
+      val service = stubService { (request, header) =>
+        header shouldBe correlationId
+        request shouldBe signUpRequest
+        Future.successful(SignUpResult.Success(signUpResponse.subscriptionId))
+      }
+      val controller = new SignUpController(Helpers.stubControllerComponents(), service)
+
+      val result = postSignUp(controller, Json.toJson(signUpRequest))
 
       status(result) shouldBe Status.OK
       contentAsJson(result).as[SignUpResponse] shouldBe signUpResponse
     }
 
     "return 400 with 'CorrelationId header not found' message" in {
-      val result = call(
-        controller.signUp,
-        FakeRequest("POST", "/sign-up")
-          .withHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
-          .withJsonBody(Json.toJson(signUpRequest))
-      )
+      val controller = controllerReturning(SignUpResult.Success(signUpResponse.subscriptionId))
+      val result     = postSignUp(controller, Json.toJson(signUpRequest), withCorrelationId = false)
 
       status(result) shouldBe Status.BAD_REQUEST
       contentAsString(result) shouldBe "CorrelationId header not found"
     }
 
-    "return 400 with 'invalid CorrelationId header' message" in {
-      val result = call(
+    "return 400 with 'Invalid CorrelationId header' message" in {
+      val controller = controllerReturning(SignUpResult.Success(signUpResponse.subscriptionId))
+      val result     = call(
         controller.signUp,
         FakeRequest("POST", "/sign-up")
           .withHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
@@ -108,15 +119,71 @@ class SignUpControllerSpec extends AnyWordSpec with Matchers with BeforeAndAfter
       contentAsString(result) shouldBe "Invalid CorrelationId header"
     }
 
-    "return 400 for an invalid request body" in {
-      val result = call(
-        controller.signUp,
-        FakeRequest("POST", "/sign-up")
-          .withHeaders(HeaderNames.CONTENT_TYPE -> MimeTypes.JSON)
-          .withJsonBody(Json.obj("idType" -> "UTR"))
-      )
+    "return 400 for an unparsable request body" in {
+      val controller = controllerReturning(SignUpResult.Success(signUpResponse.subscriptionId))
+      val result     = postSignUp(controller, Json.obj("idType" -> "UTR"))
 
       status(result) shouldBe Status.BAD_REQUEST
+    }
+
+    "return 400 when the request contains no contacts" in {
+      val controller = controllerReturning(SignUpResult.Success(signUpResponse.subscriptionId))
+      val body       = Json.toJson(signUpRequest).as[JsObject] ++ Json.obj("contacts" -> Json.arr())
+
+      status(postSignUp(controller, body)) shouldBe Status.BAD_REQUEST
+    }
+
+    "return 400 when a contact email is invalid" in {
+      val controller = controllerReturning(SignUpResult.Success(signUpResponse.subscriptionId))
+      val body       = Json.obj(
+        "etmpSafeId"       -> signUpRequest.etmpSafeId,
+        "nominatedCompany" -> Json.toJson(signUpRequest.nominatedCompany),
+        "contacts"         -> Json.arr(
+          Json.obj(
+            "name"     -> "contact 1",
+            "email"    -> "not-an-email",
+            "status"   -> "active",
+            "language" -> "en-GB"
+          )
+        )
+      )
+
+      status(postSignUp(controller, body)) shouldBe Status.BAD_REQUEST
+    }
+  }
+
+  "POST /sign-up downstream failures" should {
+    def resultFor(failure: SignUpResult): Future[Result] =
+      postSignUp(controllerReturning(failure), Json.toJson(signUpRequest))
+
+    "translate a MalformedResponse to 502 with a DOWNSTREAM_SERVICE_MISALIGNMENT error" in {
+      val result = resultFor(SignUpResult.MalformedResponse(DownstreamService.ETMP))
+      status(result) shouldBe Status.BAD_GATEWAY
+      contentAsJson(result) shouldBe Json.toJson(ApiError(Reason.DOWNSTREAM_SERVICE_MISALIGNMENT))
+    }
+
+    "translate a BadRequestFailure to 500 with a DOWNSTREAM_SERVICE_MISALIGNMENT error" in {
+      val result = resultFor(SignUpResult.BadRequestFailure(DownstreamService.DPS))
+      status(result) shouldBe Status.INTERNAL_SERVER_ERROR
+      contentAsJson(result) shouldBe Json.toJson(ApiError(Reason.DOWNSTREAM_SERVICE_MISALIGNMENT))
+    }
+
+    "translate an InternalServerFailure to 502 with a DOWNSTREAM_SERVICE_ERROR error" in {
+      val result = resultFor(SignUpResult.InternalServerFailure(DownstreamService.DPS))
+      status(result) shouldBe Status.BAD_GATEWAY
+      contentAsJson(result) shouldBe Json.toJson(ApiError(Reason.DOWNSTREAM_SERVICE_ERROR))
+    }
+
+    "translate a ServiceUnavailableFailure to 502 with a DOWNSTREAM_SERVICE_UNAVAILABLE error" in {
+      val result = resultFor(SignUpResult.ServiceUnavailableFailure(DownstreamService.DPS))
+      status(result) shouldBe Status.BAD_GATEWAY
+      contentAsJson(result) shouldBe Json.toJson(ApiError(Reason.DOWNSTREAM_SERVICE_UNAVAILABLE))
+    }
+
+    "translate an UnknownFailure to 502 with a DOWNSTREAM_SERVICE_MISALIGNMENT error" in {
+      val result = resultFor(SignUpResult.UnknownFailure(DownstreamService.TAX_ENROLMENTS, Status.IM_A_TEAPOT))
+      status(result) shouldBe Status.BAD_GATEWAY
+      contentAsJson(result) shouldBe Json.toJson(ApiError(Reason.DOWNSTREAM_SERVICE_MISALIGNMENT))
     }
   }
 }

--- a/test/uk/gov/hmrc/senioraccountingofficerregistration/services/SignUpServiceSpec.scala
+++ b/test/uk/gov/hmrc/senioraccountingofficerregistration/services/SignUpServiceSpec.scala
@@ -22,7 +22,9 @@ import org.mockito.{ArgumentCaptor, ArgumentMatchers}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
-import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
+import play.api.http.Status
+import play.api.libs.json.Json
+import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.senioraccountingofficerregistration.TestData
 import uk.gov.hmrc.senioraccountingofficerregistration.connectors.{
   DpsConnector,
@@ -30,6 +32,7 @@ import uk.gov.hmrc.senioraccountingofficerregistration.connectors.{
   TaxEnrolmentsConnector
 }
 import uk.gov.hmrc.senioraccountingofficerregistration.models.*
+import uk.gov.hmrc.senioraccountingofficerregistration.services.SignUpService.{DownstreamService, SignUpResult}
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -40,39 +43,48 @@ class SignUpServiceSpec extends AnyWordSpec with Matchers with ScalaFutures with
   private given ExecutionContext = ExecutionContext.global
   private given HeaderCarrier    = HeaderCarrier()
 
-  private val signUpRequest = generateSignUpRequest(seed = 1)
-
+  private val signUpRequest       = generateSignUpRequest(seed = 1)
   private val etmpSuccessResponse = generateEtmpSuccessResponse(seed = 4)
-  private val signUpResponse      = SignUpResponse(etmpSuccessResponse.success.dsaoIdNumber)
+  private val subscriptionId      = etmpSuccessResponse.success.dsaoIdNumber
   private val correlationId       = UUID.randomUUID().toString
 
+  private val etmpCreated = HttpResponse(Status.CREATED, Json.stringify(Json.toJson(etmpSuccessResponse)))
+
+  private def connectors(): (EtmpSubscriptionConnector, DpsConnector, TaxEnrolmentsConnector, SignUpService) = {
+    val etmpConnector          = mock(classOf[EtmpSubscriptionConnector])
+    val taxEnrolmentsConnector = mock(classOf[TaxEnrolmentsConnector])
+    val dpsConnector           = mock(classOf[DpsConnector])
+    val service                = SignUpService(etmpConnector, taxEnrolmentsConnector, dpsConnector)
+    (etmpConnector, dpsConnector, taxEnrolmentsConnector, service)
+  }
+
+  private def stubEtmp(etmpConnector: EtmpSubscriptionConnector, response: HttpResponse): Unit =
+    when(etmpConnector.signUp(anyArg[SignUpRequest], anyArg[String])(using anyArg[HeaderCarrier]))
+      .thenReturn(Future.successful(response))
+
+  private def stubDps(dpsConnector: DpsConnector, response: HttpResponse): Unit =
+    when(dpsConnector.replaceSaoSubscription(anyArg[String], anyArg[SignUpRequest])(using anyArg[HeaderCarrier]))
+      .thenReturn(Future.successful(response))
+
+  private def stubTaxEnrolments(taxEnrolmentsConnector: TaxEnrolmentsConnector, response: HttpResponse): Unit =
+    when(taxEnrolmentsConnector.enrol(anyArg[TaxEnrolmentRequest])(using anyArg[HeaderCarrier]))
+      .thenReturn(Future.successful(response))
+
   "signUp" should {
-    "call tax-enrolments with DSAO known facts after ETMP and DPS succeeds" in {
-      val etmpConnector          = mock(classOf[EtmpSubscriptionConnector])
-      val taxEnrolmentsConnector = mock(classOf[TaxEnrolmentsConnector])
-      val dpsConnector           = mock(classOf[DpsConnector])
-      val service                = SignUpService(etmpConnector, taxEnrolmentsConnector, dpsConnector)
-      val enrolmentCaptor        = ArgumentCaptor.forClass(classOf[TaxEnrolmentRequest])
-      val subscriptionId         = etmpSuccessResponse.success.dsaoIdNumber
+    "call tax-enrolments with DSAO known facts after ETMP and DPS succeed, then return Success" in {
+      val (etmpConnector, dpsConnector, taxEnrolmentsConnector, service) = connectors()
+      val enrolmentCaptor = ArgumentCaptor.forClass(classOf[TaxEnrolmentRequest])
 
-      when(etmpConnector.signUp(anyArg[SignUpRequest], anyArg[String])(using anyArg[HeaderCarrier]))
-        .thenReturn(Future.successful(etmpSuccessResponse))
-      when(
-        dpsConnector.replaceSaoSubscription(anyArg[String], anyArg[SignUpRequest], anyArg[String])(using
-          anyArg[HeaderCarrier]
-        )
-      )
-        .thenReturn(Future.successful(()))
-      when(taxEnrolmentsConnector.enrol(anyArg[TaxEnrolmentRequest])(using anyArg[HeaderCarrier]))
-        .thenReturn(Future.successful(()))
+      stubEtmp(etmpConnector, etmpCreated)
+      stubDps(dpsConnector, HttpResponse(Status.CREATED, ""))
+      stubTaxEnrolments(taxEnrolmentsConnector, HttpResponse(Status.NO_CONTENT, ""))
 
-      service.signUp(signUpRequest, correlationId).futureValue shouldBe signUpResponse
+      service.signUp(signUpRequest, correlationId).futureValue shouldBe SignUpResult.Success(subscriptionId)
 
       verify(etmpConnector).signUp(ArgumentMatchers.eq(signUpRequest), anyString())(using anyArg[HeaderCarrier])
       verify(dpsConnector).replaceSaoSubscription(
         ArgumentMatchers.eq(subscriptionId),
-        ArgumentMatchers.eq(signUpRequest),
-        anyString()
+        ArgumentMatchers.eq(signUpRequest)
       )(using anyArg[HeaderCarrier])
       verify(taxEnrolmentsConnector).enrol(enrolmentCaptor.capture())(using anyArg[HeaderCarrier])
       enrolmentCaptor.getValue shouldBe
@@ -85,72 +97,57 @@ class SignUpServiceSpec extends AnyWordSpec with Matchers with ScalaFutures with
         )
     }
 
-    "not call DPS after ETMP fails" in {
-      val etmpConnector          = mock(classOf[EtmpSubscriptionConnector])
-      val taxEnrolmentsConnector = mock(classOf[TaxEnrolmentsConnector])
-      val dpsConnector           = mock(classOf[DpsConnector])
-      val service                = SignUpService(etmpConnector, taxEnrolmentsConnector, dpsConnector)
+    "return MalformedResponse(ETMP) and not call DPS when ETMP returns 201 with an unparsable body" in {
+      val (etmpConnector, dpsConnector, _, service) = connectors()
+      stubEtmp(etmpConnector, HttpResponse(Status.CREATED, "not json"))
 
-      when(etmpConnector.signUp(anyArg[SignUpRequest], anyArg[String])(using anyArg[HeaderCarrier]))
-        .thenReturn(Future.failed(UpstreamErrorResponse("ETMP failed", 500)))
+      service.signUp(signUpRequest, correlationId).futureValue shouldBe
+        SignUpResult.MalformedResponse(DownstreamService.ETMP)
 
-      service.signUp(signUpRequest, correlationId).failed.futureValue shouldBe a[UpstreamErrorResponse]
-
-      verify(dpsConnector, never()).replaceSaoSubscription(anyArg[String], anyArg[SignUpRequest], anyArg[String])(using
+      verify(dpsConnector, never()).replaceSaoSubscription(anyArg[String], anyArg[SignUpRequest])(using
         anyArg[HeaderCarrier]
       )
     }
 
-    "not call tax-enrolments when DPS fails" in {
-      val etmpConnector          = mock(classOf[EtmpSubscriptionConnector])
-      val taxEnrolmentsConnector = mock(classOf[TaxEnrolmentsConnector])
-      val dpsConnector           = mock(classOf[DpsConnector])
-      val service                = SignUpService(etmpConnector, taxEnrolmentsConnector, dpsConnector)
+    "return InternalServerFailure(ETMP) and not call DPS when ETMP returns 500" in {
+      val (etmpConnector, dpsConnector, _, service) = connectors()
+      stubEtmp(etmpConnector, HttpResponse(Status.INTERNAL_SERVER_ERROR, ""))
 
-      when(etmpConnector.signUp(anyArg[SignUpRequest], anyArg[String])(using anyArg[HeaderCarrier]))
-        .thenReturn(Future.successful(etmpSuccessResponse))
-      when(
-        dpsConnector.replaceSaoSubscription(anyArg[String], anyArg[SignUpRequest], anyArg[String])(using
-          anyArg[HeaderCarrier]
-        )
+      service.signUp(signUpRequest, correlationId).futureValue shouldBe
+        SignUpResult.InternalServerFailure(DownstreamService.ETMP)
+
+      verify(dpsConnector, never()).replaceSaoSubscription(anyArg[String], anyArg[SignUpRequest])(using
+        anyArg[HeaderCarrier]
       )
-        .thenReturn(Future.failed(UpstreamErrorResponse("DPS failed", 500)))
-
-      service.signUp(signUpRequest, correlationId).failed.futureValue shouldBe a[UpstreamErrorResponse]
-      verify(taxEnrolmentsConnector, never()).enrol(anyArg[TaxEnrolmentRequest])(using anyArg[HeaderCarrier])
-    }
-    "not call tax-enrolments when ETMP fails" in {
-      val etmpConnector          = mock(classOf[EtmpSubscriptionConnector])
-      val taxEnrolmentsConnector = mock(classOf[TaxEnrolmentsConnector])
-      val dpsConnector           = mock(classOf[DpsConnector])
-      val service                = SignUpService(etmpConnector, taxEnrolmentsConnector, dpsConnector)
-
-      when(etmpConnector.signUp(anyArg[SignUpRequest], anyArg[String])(using anyArg[HeaderCarrier]))
-        .thenReturn(Future.failed(UpstreamErrorResponse("ETMP failed", 500)))
-
-      service.signUp(signUpRequest, correlationId).failed.futureValue shouldBe a[UpstreamErrorResponse]
-
-      verify(taxEnrolmentsConnector, never()).enrol(anyArg[TaxEnrolmentRequest])(using anyArg[HeaderCarrier])
     }
 
-    "fail when tax-enrolments fails" in {
-      val etmpConnector          = mock(classOf[EtmpSubscriptionConnector])
-      val taxEnrolmentsConnector = mock(classOf[TaxEnrolmentsConnector])
-      val dpsConnector           = mock(classOf[DpsConnector])
-      val service                = SignUpService(etmpConnector, taxEnrolmentsConnector, dpsConnector)
+    "return UnknownFailure(ETMP, status) for an unmapped ETMP status" in {
+      val (etmpConnector, _, _, service) = connectors()
+      stubEtmp(etmpConnector, HttpResponse(Status.IM_A_TEAPOT, ""))
 
-      when(etmpConnector.signUp(anyArg[SignUpRequest], anyArg[String])(using anyArg[HeaderCarrier]))
-        .thenReturn(Future.successful(etmpSuccessResponse))
-      when(
-        dpsConnector.replaceSaoSubscription(anyArg[String], anyArg[SignUpRequest], anyArg[String])(using
-          anyArg[HeaderCarrier]
-        )
-      )
-        .thenReturn(Future.successful(()))
-      when(taxEnrolmentsConnector.enrol(anyArg[TaxEnrolmentRequest])(using anyArg[HeaderCarrier]))
-        .thenReturn(Future.failed(UpstreamErrorResponse("tax-enrolments failed", 500)))
+      service.signUp(signUpRequest, correlationId).futureValue shouldBe
+        SignUpResult.UnknownFailure(DownstreamService.ETMP, Status.IM_A_TEAPOT)
+    }
 
-      service.signUp(signUpRequest, correlationId).failed.futureValue shouldBe a[UpstreamErrorResponse]
+    "return ServiceUnavailableFailure(DPS) and not call tax-enrolments when DPS returns 503" in {
+      val (etmpConnector, dpsConnector, taxEnrolmentsConnector, service) = connectors()
+      stubEtmp(etmpConnector, etmpCreated)
+      stubDps(dpsConnector, HttpResponse(Status.SERVICE_UNAVAILABLE, ""))
+
+      service.signUp(signUpRequest, correlationId).futureValue shouldBe
+        SignUpResult.ServiceUnavailableFailure(DownstreamService.DPS)
+
+      verify(taxEnrolmentsConnector, never()).enrol(anyArg[TaxEnrolmentRequest])(using anyArg[HeaderCarrier])
+    }
+
+    "return BadRequestFailure(TAX_ENROLMENTS) when tax-enrolments returns 400" in {
+      val (etmpConnector, dpsConnector, taxEnrolmentsConnector, service) = connectors()
+      stubEtmp(etmpConnector, etmpCreated)
+      stubDps(dpsConnector, HttpResponse(Status.CREATED, ""))
+      stubTaxEnrolments(taxEnrolmentsConnector, HttpResponse(Status.BAD_REQUEST, ""))
+
+      service.signUp(signUpRequest, correlationId).futureValue shouldBe
+        SignUpResult.BadRequestFailure(DownstreamService.TAX_ENROLMENTS)
     }
   }
 }


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* Connectors return the raw `HttpResponse` instead of throwing; `SignUpService` maps each downstream response to a typed `SignUpResult`.
* `SignUpController` returns a sanitised `ApiError` (reason only) instead of the downstream body, and logs failures with the correlationId. 400 -> 500, 500/503/unknown -> 502.
* Added request validation: reject invalid contact email and empty contacts.
* Updated the Bruno `post sign up` fixture and unit tests.

## Jira ticket(s):
* SAOD-865

## Checklist
* [x] Have you consulted with a QA?
    * [x] Tick if you expect this work could break the existing Acceptance Test
* [ ] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [ ] Have you run the unit test?
* [ ] Have you run the it/test?
* [ ] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [ ] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
