### PR TITLE
SAOD-1029 update API paths

### DIFF
--- a/app/uk/gov/hmrc/senioraccountingofficerregistration/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/senioraccountingofficerregistration/config/AppConfig.scala
@@ -29,10 +29,10 @@ class AppConfig @Inject() (servicesConfig: ServicesConfig, config: Configuration
   val appName: String = config.get[String]("appName")
 
   val etmpSubscriptionUrl: String =
-    s"${servicesConfig.baseUrl("hip")}/RESTAdapter/dsao/subscription"
+    s"${servicesConfig.baseUrl("hip")}/etmp/RESTAdapter/dsao/subscription"
 
   val dpsReplaceSaoSubscriptionUrl: String =
-    s"${servicesConfig.baseUrl("hip")}/subscriptions/"
+    s"${servicesConfig.baseUrl("hip")}/dapm/subscriptions"
 
   val taxEnrolmentsDsaoEnrolmentUrl: String =
     s"${servicesConfig.baseUrl("tax-enrolments")}/tax-enrolments/service/HMRC-DSAO-ORG/enrolment"

--- a/bruno/environments/local.yml
+++ b/bruno/environments/local.yml
@@ -8,3 +8,4 @@ variables:
     value: http://localhost:10056/senior-accounting-officer
   - secret: true
     name: authorization
+    description: ""

--- a/test/uk/gov/hmrc/senioraccountingofficerregistration/connectors/DpsConnectorSpec.scala
+++ b/test/uk/gov/hmrc/senioraccountingofficerregistration/connectors/DpsConnectorSpec.scala
@@ -77,7 +77,7 @@ class DpsConnectorSpec
       val subscriptionId        = "123"
 
       wireMockServer.stubFor(
-        put(s"/subscriptions/${subscriptionId}")
+        put(s"/dapm/subscriptions/${subscriptionId}")
           .withHeader(HeaderNames.CONTENT_TYPE, containing(MimeTypes.JSON))
           .withRequestBody(equalToJson(Json.stringify(expectedSignUpRequest)))
           .willReturn(aResponse().withStatus(Status.CREATED))
@@ -93,7 +93,7 @@ class DpsConnectorSpec
       val subscriptionId        = "456"
 
       wireMockServer.stubFor(
-        put(s"/subscriptions/${subscriptionId}")
+        put(s"/dapm/subscriptions/${subscriptionId}")
           .withHeader(HeaderNames.CONTENT_TYPE, containing(MimeTypes.JSON))
           .withRequestBody(equalToJson(Json.stringify(expectedSignUpRequest)))
           .willReturn(aResponse().withStatus(Status.INTERNAL_SERVER_ERROR))

--- a/test/uk/gov/hmrc/senioraccountingofficerregistration/connectors/EtmpSubscriptionConnectorSpec.scala
+++ b/test/uk/gov/hmrc/senioraccountingofficerregistration/connectors/EtmpSubscriptionConnectorSpec.scala
@@ -82,7 +82,7 @@ class EtmpSubscriptionConnectorSpec
       )
 
       wireMockServer.stubFor(
-        post(urlEqualTo("/RESTAdapter/dsao/subscription"))
+        post(urlEqualTo("/etmp/RESTAdapter/dsao/subscription"))
           .withHeader(HeaderNames.CONTENT_TYPE, containing(MimeTypes.JSON))
           .withHeader(HeaderNames.AUTHORIZATION, equalTo("Basic c29tZS1jbGllbnQtaWQ6c29tZS1jbGllbnQtc2VjcmV0"))
           .withHeader("X-Transmitting-System", equalTo("HIP"))
@@ -107,7 +107,7 @@ class EtmpSubscriptionConnectorSpec
       val request = generateSignUpRequest(seed = 1)
 
       wireMockServer.stubFor(
-        post(urlEqualTo("/RESTAdapter/dsao/subscription"))
+        post(urlEqualTo("/etmp/RESTAdapter/dsao/subscription"))
           .willReturn(aResponse().withStatus(Status.INTERNAL_SERVER_ERROR))
       )
 


### PR DESCRIPTION
# Pull Request Description
## List the changes made in comparison to main:
* Added server domain to the respective URL path

## Jira ticket(s):
* [SAOD-1029](https://jira.tools.tax.service.gov.uk/browse/SAOD-1029)

## Checklist
* [ ] Have you consulted with a QA?
    * [ ] Tick if you expect this work could break the existing Acceptance Test
* [x] Is the branch up to date with main?
* [x] Have you added tests for any changed functionality?
* [x] Have you run the unit test?
* [x] Have you run the it/test?
* [ ] Have you run the [senior-accounting-officer-acceptance-tests](https://github.com/hmrc/senior-accounting-officer-acceptance-tests) suite `run_all_tests.sh`?
* [x] Have you formatted the new/updated Scala sources using `sbt lint`?
* [ ] Does this work need to be coordinated with any other work currently in flight?
  * If ticked please state them below
   * [stubs PR](https://github.com/hmrc/senior-accounting-officer-stubs/pull/71)
   * [protected service PR](https://github.com/hmrc/senior-accounting-officer/pull/66)